### PR TITLE
Update READMEs for modules

### DIFF
--- a/load_balancers/complete_https_and_tcp_with_kms/certs_and_lbs/README.md
+++ b/load_balancers/complete_https_and_tcp_with_kms/certs_and_lbs/README.md
@@ -17,7 +17,7 @@ the module is ready for execution.
 
 Make sure that the `GOOGLE_APPLICATION_CREDENTIALS` environment variable has
 been populated with the path to the JSON key for the load balancer service
-account that was created by the first module. If it has not been set or the
+account that was created by the `service_account` module. If it has not been set or the
 JSON key has not been downloaded, then you will need to ensure both of those
 steps have been followed
 

--- a/load_balancers/complete_https_and_tcp_with_kms/kms_setup/README.md
+++ b/load_balancers/complete_https_and_tcp_with_kms/kms_setup/README.md
@@ -5,6 +5,14 @@ key necessary for encrypting secrets. If you have one or more of those
 already built feel free to use them, but if not then create them by executing
 this Terraform module (you will need to provide a `project_id` and `region`)
 
+Make sure that the `GOOGLE_APPLICATION_CREDENTIALS` environment variable has
+been populated with the path to the JSON key for the load balancer service
+account that was created by the `service_account` module. If it has not been
+set or the JSON key has not been downloaded, then you will need to ensure
+both of those steps have been followed.
+
+Next, execute Terraform:
+
     terraform init
     terraform plan -out kms.out
     terraform apply kms.out

--- a/load_balancers/complete_https_and_tcp_with_kms/network/README.md
+++ b/load_balancers/complete_https_and_tcp_with_kms/network/README.md
@@ -1,0 +1,20 @@
+# Network configuration
+
+This module exists as a standalone dependency necessary to create the VPC
+network and subnetwork that will be needed for later infrastructure, as well
+as the NAT gateway used by the Managed Instance Group (MIG) VM instances so
+they can download and install Nginx from yum mirrors (to avoid needing external IP addresses). Should you already have all of these resources then
+this module isn't necessary, however this module is tightly-coupled with the
+`certs_and_lbs` module (for providing the network and subnetwork name), so
+modifications will need to be made there.
+
+The only input variables required are `project_id` and `region`, so once those
+have been configured simply execute Terraform:
+
+    terraform init
+    terraform plan -out network.out
+    terraform apply network.out
+
+THIS module must be executed with an identity/service account that has enough
+permission to create a network/subnetwork within `project_id` and bring up the
+NAT gateway.

--- a/load_balancers/complete_https_and_tcp_with_kms/service_account/README.md
+++ b/load_balancers/complete_https_and_tcp_with_kms/service_account/README.md
@@ -1,0 +1,16 @@
+# Service account configuration
+
+The intent of this module is to generate a service account that will be used to
+execute both the `kms_setup` and `certs_and_lbs` modules. The purpose is to
+demonstrate which IAM roles are necessary for whatever service account will be
+used to execute this code in your environment.
+
+The only input variable available is `project_id`, so once you provide that simply run Terraform:
+
+    terraform init
+    terraform plan -out sa.out
+    terraform apply sa.out
+
+THIS module must be executed with an identity/service account that has enough
+permission to create a service account with the project specified by 
+`project_id` and assign IAM roles to it.


### PR DESCRIPTION
This commit introduces the README files for the `service_account` and
`netweork` Terraform modules within the load balancer example.